### PR TITLE
Add support for target token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /old/
 /.vscode/
+Cargo.lock

--- a/diskplan-schema/src/text.rs
+++ b/diskplan-schema/src/text.rs
@@ -111,6 +111,7 @@ fn schema_node<'t>(
             Operator::Owner(owner) => builder.owner(owner),
             Operator::Group(group) => builder.group(group),
             Operator::Source(source) => builder.source(source),
+            Operator::Target(target) => builder.target(target),
 
             // Operators that apply to child items
             Operator::Let { name, expr } => builder.let_var(name, expr),
@@ -210,6 +211,7 @@ fn operator(level: usize) -> impl Fn(&str) -> Res<&str, (&str, Operator)> {
         let owner_op = op("owner", expression);
         let group_op = op("group", expression);
         let source_op = op("source", expression);
+        let target_op = op("target", expression);
 
         consumed(alt((
             delimited(
@@ -223,6 +225,7 @@ fn operator(level: usize) -> impl Fn(&str) -> Res<&str, (&str, Operator)> {
                     map(owner_op, Operator::Owner),
                     map(group_op, Operator::Group),
                     map(source_op, Operator::Source),
+                    map(target_op, Operator::Target),
                 )),
                 end_of_lines,
             ),
@@ -287,6 +290,7 @@ enum Operator<'t> {
     Owner(Expression<'t>),
     Group(Expression<'t>),
     Source(Expression<'t>),
+    Target(Expression<'t>),
 }
 
 fn blank_line(s: &str) -> Res<&str, &str> {

--- a/diskplan-schema/src/text/builder.rs
+++ b/diskplan-schema/src/text/builder.rs
@@ -168,6 +168,14 @@ impl<'t> SchemaNodeBuilder<'t> {
         }
     }
 
+    pub fn target(&mut self, target: Expression<'t>) -> Result<()> {
+        if self.symlink.is_some() {
+            bail!(":target occurs twice");
+        }
+        self.symlink = Some(target);
+        Ok(())
+    }
+
     pub fn add_entry(&mut self, binding: Binding<'t>, entry: SchemaNode<'t>) -> Result<()> {
         match &mut self.type_specific {
             TypeSpecific::File { .. } => Err(anyhow!(

--- a/diskplan-traversal/src/tests/creation.rs
+++ b/diskplan-traversal/src/tests/creation.rs
@@ -80,6 +80,42 @@ fn create_symlink() -> Result<()> {
 }
 
 #[test]
+fn create_symlink_using_target() -> Result<()> {
+    assert_effect_of! {
+        under: "/primary"
+        applying: "
+            subdirlink/
+                :target /secondary/${NAME}
+                subfile
+                    :source /resource/file
+            "
+
+        under: "/secondary"
+        applying: "
+            $_a/
+                $_b/
+                    $_c/
+            "
+
+        onto: "/primary"
+        with:
+            directories:
+                "/resource"
+            files:
+                "/resource/file" ["FILE CONTENT"]
+        yields:
+            directories:
+                "/primary"
+                "/secondary"
+                "/secondary/subdirlink"
+            files:
+                "/secondary/subdirlink/subfile" ["FILE CONTENT"]
+            symlinks:
+                "/primary/subdirlink" -> "/secondary/subdirlink"
+    }
+}
+
+#[test]
 fn create_relative_symlink() -> Result<()> {
     assert_effect_of! {
         under: "/"


### PR DESCRIPTION
Add support for a new `:target` token that has the same functionality as `->` for creating symlinks.